### PR TITLE
add id field to bank_statements schema

### DIFF
--- a/tap_codat/schemas/bank_statements.json
+++ b/tap_codat/schemas/bank_statements.json
@@ -14,6 +14,9 @@
         "string"
       ]
     },
+    "id": {
+        "type": ["null", "string"]
+    },
     "balance": {
         "type": ["null", "string"]
     },


### PR DESCRIPTION
This PR adds the `id` field to the `bank_statements` schema, fixing a validation error. I tested it by running this tap manually, and confirming that the tap completed successfully.

More broadly: The Codat API appears to change in ways that break this tap on a somewhat frequent basis. @cmerrick is it appropriate to turn on `additionalProperties: true` to prevent errors when new fields are added?