### PR TITLE
fix for inconsistent c strftime implementations

### DIFF
--- a/tap_codat/transform.py
+++ b/tap_codat/transform.py
@@ -1,6 +1,5 @@
 import pendulum
 from singer.utils import strftime as singer_strftime
-import sys
 
 
 class DictKey(object):


### PR DESCRIPTION
This PR tweaks the implementation of `strftime` to:

- try using the Singer strftime implementation
- fall back to an alternative date fmt string: `%Y-%m-%dT%H:%M:%S.%fZ`

As a result, tap-codat should now work on any system regardless of the underlying C strftime implementation