### PR TITLE
Fix for missing "accountId" on some reports

### DIFF
--- a/tap_codat/streams.py
+++ b/tap_codat/streams.py
@@ -116,7 +116,7 @@ def flatten_report(item, parent_names=[]):
     item_tformed = {
         "name": item["name"],
         "value": item["value"],
-        "accountId": item["accountId"],
+        "accountId": item.get("accountId", None),
     }
     for idx, parent_name in enumerate(parent_names):
         item_tformed["name_" + str(idx)] = parent_name


### PR DESCRIPTION
In the financial reports (balance sheet and profit & loss), there are certain items which are standard rather than accounts, and these do not have IDs. Previously these fields had a `null` value for the `accountId` field, but a recent change means they do not have an entry for `accountId` at all. So this change simply treats the lack of the key as a `null` value.