### PR TITLE
TDL-19773: Change Data Fetching Key For Stream Company

### DIFF
--- a/tap_codat/streams.py
+++ b/tap_codat/streams.py
@@ -138,7 +138,7 @@ class Companies(Stream):
 
     def fetch_into_cache(self, ctx):
         resp = self.raw_fetch(ctx)
-        ctx.cache["companies"] = self.transform_dts(ctx, resp["companies"])
+        ctx.cache["companies"] = self.transform_dts(ctx, resp["results"])
 
     def sync(self, ctx):
         self.write_records(ctx.cache["companies"])


### PR DESCRIPTION
# Description of change
 - For Stream Company stream data fetching key is replaced from "companies" to "results".

# Manual QA steps
 - Check whether we are getting data or not in sync mode for the Company stream
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
