### PR TITLE
Version 0.5.1 and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.1
+  * Fix KeyError on `companies` stream due to API response key being renamed to `results` [#14](https://github.com/singer-io/tap-codat/pull/14)
+
 ## 0.5.0
 **Functional changes:**
 - Retry requests which fail with a 500, 501, or 502 error code

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-codat",
-    version="0.5.0",
+    version="0.5.1",
     description="Singer.io tap for extracting data from the Codat API",
     author="Stitch",
     url="http://singer.io",


### PR DESCRIPTION
# Description of change
Releasing the change merged in #14 

# Manual QA steps
 - None, this is a KeyError which is very straightforward, and has been brought up by quite a few people who have been able to fix it on their side. The new key is taken on trust of this effort.
 
# Risks
 - Low, as explained above.
 
# Rollback steps
 - revert #14, bump patch version, re-release
