### PR TITLE
Don't hard fail on 409 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.2
+  * Don't hard fail syncing on 409 errors, instead accumulate logs and continue syncing other companies. [#19](https://github.com/singer-io/tap-codat/pull/19/files)
+
 ## 0.5.1
   * Fix KeyError on `companies` stream due to API response key being renamed to `results` [#14](https://github.com/singer-io/tap-codat/pull/14)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="tap-codat",
-    version="0.5.1",
+    version="0.5.2",
     description="Singer.io tap for extracting data from the Codat API",
     author="Stitch",
     url="http://singer.io",

--- a/tap_codat/__init__.py
+++ b/tap_codat/__init__.py
@@ -99,6 +99,7 @@ def main_impl():
         ctx.catalog = Catalog.from_dict(args.properties) \
             if args.properties else discover(ctx)
         sync(ctx)
+        ctx.dump_logs()
 
 
 def main():

--- a/tap_codat/context.py
+++ b/tap_codat/context.py
@@ -66,3 +66,8 @@ class Context(object):
 
     def write_state(self):
         singer.write_state(self.state)
+
+    def dump_logs(self):
+        """Write accumulated logs to std out."""
+        # Client logs
+        self.client.write_and_clear_accumulated_logs()

--- a/tap_codat/http.py
+++ b/tap_codat/http.py
@@ -23,6 +23,7 @@ class Client(object):
         self.session = requests.Session()
         self.b64key = b64encode(config["api_key"].encode()).decode("utf-8")
         self.base_url = UAT_URL if config.get("uat_urls").lower() == "true" else BASE_URL
+        self.logs = []
 
     def prepare_and_send(self, request):
         if self.user_agent:
@@ -44,13 +45,26 @@ class Client(object):
         with metrics.http_request_timer(tap_stream_id) as timer:
             response = self.prepare_and_send(request)
             timer.tags[metrics.Tag.http_status_code] = response.status_code
+        
+        log = {
+            "tap_stream_id": tap_stream_id,
+            "status_code": response.status_code,
+            "url": response.url,
+        }
+    
         if response.status_code in [429, 500, 501, 502, 503]:
             raise RateLimitException()
         elif response.status_code == 409:
             # caused by broken connection on codat's side
-            LOGGER.warning(f"Failed to fetch: {response.reason}")
+            log_msg = f"failed to fetch due to {response.status_code} status code"
+            LOGGER.warning(log_msg)
+            log["msg"] = log_msg
+            self.logs.append(log)            
             return None           
         elif response.status_code == 404:
+            log_msg = f"failed to fetch due to {response.status_code} status code"
+            LOGGER.warning(log_msg)
+            self.logs.append(log)
             return None
         response.raise_for_status()
         return response.json()
@@ -58,3 +72,7 @@ class Client(object):
     def GET(self, request_kwargs, *args, **kwargs):
         req = self.create_get_request(**request_kwargs)
         return self.request_with_handling(req, *args, **kwargs)
+
+    def write_and_clear_accumulated_logs(self):
+        LOGGER.info(f"Writing accumulated Client logs: {self.logs}")
+        self.logs = []


### PR DESCRIPTION
# Description of change
When running the codat tap in Stitch data, I noticed the following uncaught error:

```
2022-08-16 23:00:23,383Z   main - INFO Exit status is: Discovery succeeded. Tap failed with code 1 and error message: "409 Client Error: Conflict for url: https://api.codat.io/companies/<redacted company ID>/data/invoices?pageSize=500&page=1&orderBy=modifiedDate&query=modifiedDate%3E2017-08-01T00%3A00%3A00Z". Target succeeded.
```

It looks like that error is caused by a syncing issue on Codat's side. From the codat UI + the payload response from the request above:

![image](https://user-images.githubusercontent.com/1908028/185003628-2a607ddb-7193-4eb8-bba7-b828931b4473.png)

```
{
    "statusCode": 409,
    "service": "PublicApi",
    "error": "Datatype 'invoices' has not yet been requested or is not yet complete",
    "correlationId": "some ID",
    "canBeRetried": "Unknown",
    "detailedErrorCode": 0
}
```

Rather than hard failing for this error, we should warn and proceed with syncing.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
